### PR TITLE
Fix 'it' bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,9 +218,9 @@
 <script src="https://code.jquery.com/qunit/qunit-2.0.1.js"></script>
 <script src="./qUnit/test.js"></script>
 -->
+
 <script src="./js/config.js"></script>
 <script src="./js/app.js"></script>
-
 
 </body>
 


### PR DESCRIPTION
There was a rogue 'it' written in the HTML doc and it was displaying on the screen.